### PR TITLE
Update socket.io javascript version.

### DIFF
--- a/instant_rst/templates/index.html
+++ b/instant_rst/templates/index.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/0.9.16/socket.io.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/1.3.6/socket.io.min.js"></script>
 <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
 <link rel="stylesheet" href="/static/rhythm.css">
 <link rel="stylesheet" href="/static/molokai.css">


### PR DESCRIPTION
This commit updates the version of socket.io.min.js from 0.9.16 to 1.3.6
so that we can run InstantRst with flask-socketio 1.2.

Fix #9