### PR TITLE
Fix additional_dir serving

### DIFF
--- a/instant_rst/server.py
+++ b/instant_rst/server.py
@@ -39,8 +39,8 @@ def run(host, port, template_dir, static_dir, additional_dirs, default_file):
 def serve_additional_file(directory, filename):
     print 'ADD_STATIC'
     print ADDITIONAL_DIRS
-    print additional_dir
     for additional_dir in ADDITIONAL_DIRS:
+        print additional_dir
         if additional_dir == directory:
             # send with a file of relative path
             return send_from_directory(
@@ -111,7 +111,6 @@ def page_not_found(e):
 
 @app.errorhandler(500)
 def server_error(e):
-    console.log(e)
     return render_template('500.html', err=e), 500
 
 def shutdown_server():


### PR DESCRIPTION
Removing undefined cases, and moving a referenced variable after being
defined. Was getting 500 errors on serving because of several issues fixed in this pull request.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 193, in run_wsgi
    execute(self.server.app)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/serving.py", line 181, in execute
    application_iter = app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask_socketio/__init__.py", line 37, in __call__
    start_response)
  File "/usr/local/lib/python2.7/dist-packages/engineio/middleware.py", line 49, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1410, in handle_exception
    return handler(e)
  File "/usr/local/lib/python2.7/dist-packages/instant_rst/server.py", line 114, in server_error
    console.log(e)
NameError: global name 'console' is not defined
```

and then later

```
local variable 'additional_dir' referenced before assignment 
```